### PR TITLE
airflow-cli to depend on airflow common services

### DIFF
--- a/airflow-core/docs/howto/docker-compose/docker-compose.yaml
+++ b/airflow-core/docs/howto/docker-compose/docker-compose.yaml
@@ -279,6 +279,8 @@ services:
       - bash
       - -c
       - airflow
+    depends_on:
+      <<: *airflow-common-depends-on
 
   # You can enable flower by adding "--profile flower" option e.g. docker-compose --profile flower up
   # or by explicitly targeted on the command line e.g. docker-compose up flower.


### PR DESCRIPTION
Several airflow cli commands would fail if the airflow common dependencies are removed. Adding  airflow-common-depends-on

